### PR TITLE
Fix: Allow all characters in the projectName portion of filename

### DIFF
--- a/src/services/tokenRegistryService.ts
+++ b/src/services/tokenRegistryService.ts
@@ -6,7 +6,7 @@ import { CacheEntry, Cache } from "../models/cache";
 import { GithubItem } from "../models/github";
 import logger from "../config/logger";
 
-const FILE_NAME_REGEXP = new RegExp(/(?<project>\w+)-(?<id>\w+).json/);
+const FILE_NAME_REGEXP = new RegExp(/(?<project>\S+)-(?<id>\w+).json/);
 
 class TokenRegistryService {
     private readonly config: CONFIG;


### PR DESCRIPTION
Changed the regex to allow all characters in the projectName part of a Github filename in token-whitelist.
We still split the projectName from nft/nt Id by `-`.

Resolves https://github.com/iotaledger/token-registry/issues/2