### PR TITLE
Feat: Switch to Github Tree API for fetching asset folder files and metadata

### DIFF
--- a/src/config/axios.ts
+++ b/src/config/axios.ts
@@ -1,14 +1,36 @@
 import axios from "axios";
 
+const githubToken = process.env.GITHUB_TOKEN;
+if (!githubToken) {
+    throw new Error("Github API token not set.");
+}
+
 const githubApiRootPath = process.env.GITHUB_API_WHITELIST_ROOT;
 if (!githubApiRootPath) {
     throw new Error("Github api root path not set.");
 }
 
-export const githubApiClient = axios.create({
-    baseURL: githubApiRootPath,
+export const contentClient = axios.create({
+    baseURL: `${githubApiRootPath}/contents`,
     headers: {
-        "Accept": "application/vnd.github+json"
+        "Accept": "application/vnd.github+json",
+        "Authorization": `Bearer ${githubToken}`
+    }
+});
+
+export const treeClient = axios.create({
+    baseURL: `${githubApiRootPath}/git/trees`,
+    headers: {
+        "Accept": "application/vnd.github+json",
+        "Authorization": `Bearer ${githubToken}`
+    }
+});
+
+export const blobsClient = axios.create({
+    baseURL: `${githubApiRootPath}/git/blobs`,
+    headers: {
+        "Accept": "application/vnd.github+json",
+        "Authorization": `Bearer ${githubToken}`
     }
 });
 

--- a/src/models/github.ts
+++ b/src/models/github.ts
@@ -3,8 +3,28 @@ import { z } from "zod";
 const GithubItem = z.object({
     name: z.string(),
     type: z.string(),
+    sha: z.string(),
     download_url: z.string(),
 });
 
 export type GithubItem = z.infer<typeof GithubItem>;
+
+const GithubTreeItem = z.object({
+    path: z.string(),
+    sha: z.string(),
+    type: z.string(),
+    url: z.string()
+})
+
+export type GithubTreeItem = z.infer<typeof GithubTreeItem>;
+
+export interface GithubTreeResponse {
+    tree: GithubTreeItem[]
+}
+
+const GithubBlobItem = z.object({
+    content: z.string()
+});
+
+export type GithubBlobItem = z.infer<typeof GithubBlobItem>;
 

--- a/src/services/tokenRegistryService.ts
+++ b/src/services/tokenRegistryService.ts
@@ -47,16 +47,17 @@ class TokenRegistryService {
     }
 
     private populateCache() {
-        void this.refreshFolderHashes().then((shouldUpdateAssetData: AssetUpdateFlags | undefined) => {
+        void this.refreshFolderHashes().then((assetUpdateFlags: AssetUpdateFlags | undefined) => {
             logger.debug("Populating cache...");
             for (const network of this.config.networks) {
                 for (const asset of this.config.assets) {
                     const networkAssetKey = `${network}/${asset}`;
+                    const shouldRefreshData = assetUpdateFlags && assetUpdateFlags[networkAssetKey];
 
-                    if (shouldUpdateAssetData && shouldUpdateAssetData[networkAssetKey]) {
+                    if (shouldRefreshData) {
                         void this.fetchAssetData(network, asset);
                     } else {
-                        logger.debug(`Skipping fetch for asset data ${network}/${asset}. No changes.`)
+                        logger.debug(`Skipping fetch for asset data ${network}/${asset}. Nothing changed.`)
                     }
                 }
             }
@@ -86,9 +87,8 @@ class TokenRegistryService {
                     for (const asset of this.config.assets) {
                         const assetItem = networkAssets.find(na => na.name === asset);
                         if (assetItem) {
-                            logger.debug(`Adding to network/asset sha ${assetItem.sha} for ${network}/${asset}`);
                             const mapKey = `${network}/${asset}`;
-
+                            logger.debug(`Adding to network/asset sha ${assetItem.sha} for ${network}/${asset}`);
                             const existingSha = this.assetToChecksum.get(mapKey);
 
                             if (!existingSha) {
@@ -174,7 +174,9 @@ class TokenRegistryService {
                         ).toString("utf8")
                     ) as object;
 
+
                     if (Object.keys(metadata).length > 0) {
+                        logger.debug(`Adding cache entry for ${network}/${assetType} asset id: ${assetId}`);
                         assetCacheEntryUpdate.set(assetId, { projectName, metadata });
                     } else {
                         logger.warn(`Bad metadata content for ${assetType} with id ${assetId} (${network}). Skipping updating cache for this item.`);

--- a/src/services/tokenRegistryService.ts
+++ b/src/services/tokenRegistryService.ts
@@ -175,7 +175,7 @@ class TokenRegistryService {
                     ) as object;
 
 
-                    if (Object.keys(metadata).length > 0) {
+                    if (metadata) {
                         logger.debug(`Adding cache entry for ${network}/${assetType} asset id: ${assetId}`);
                         assetCacheEntryUpdate.set(assetId, { projectName, metadata });
                     } else {
@@ -189,6 +189,7 @@ class TokenRegistryService {
             }
         }
 
+        logger.info(`Refreshing asset data for ${network}/${assetType} finished! Replacing cache entry.`)
         this.cache[network][assetType] = assetCacheEntryUpdate;
     }
 }


### PR DESCRIPTION
- Change logic of folder contents fetching to Github Tree API to enable "more than 1000 results"
- Added logic to refresh data only if the folder contents changed

Closes https://github.com/iotaledger/token-registry/issues/4

Github API key is needed now.