### PR TITLE
Fix: Refresh cache data only for changed files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "token-registry",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "token-registry",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "dependencies": {
         "axios": "^1.2.3",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "token-registry",
   "description": "A simple service which reads out whitelisted tokens/NFTs and serves an API to query for them.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "scripts": {
     "build-clean": "rimraf ./dist/*",
     "build-compile": "tsc",

--- a/src/services/tokenRegistryService.ts
+++ b/src/services/tokenRegistryService.ts
@@ -55,7 +55,11 @@ class TokenRegistryService {
 
     private populateCache() {
         void this.refreshFolderHashes().then((fileUpdateFlags: FileUpdateFlags[]) => {
-            logger.debug("Populating cache...");
+            if (fileUpdateFlags.length > 0) {
+                logger.debug("Updating cache...");
+            } else {
+                logger.debug("Cache is up-to-date!");
+            }
             for (const asset of fileUpdateFlags) {
                 if (asset.shouldDelete) {
                     this.deleteAssetData(asset);
@@ -198,7 +202,7 @@ class TokenRegistryService {
         }
 
         //find files that were deleted from github
-        if(itemToChecksum && gitItemsCount !== itemToChecksum.size) {
+        if (itemToChecksum && gitItemsCount !== itemToChecksum.size) {
             for (const [key, value] of itemToChecksum) {
                 const foundItem = githubTree.find(gitItem => value === gitItem.sha)
                 if (!foundItem) {
@@ -218,7 +222,7 @@ class TokenRegistryService {
     }
 
     private async fetchAssetData(asset: FileUpdateFlags) {
-        const {network, assetType, projectName, assetId, sha} = asset;
+        const { network, assetType, projectName, assetId, sha } = asset;
 
         try {
             const response = await blobsClient.get(`/${sha}`);
@@ -240,15 +244,15 @@ class TokenRegistryService {
             } else {
                 logger.warn(`Bad metadata content for ${assetType} with id ${assetId} (${network}). Skipping updating cache for this item.`);
             }
-        } catch {
+        } catch (error) {
             logger.error(
-                `Failed to fetch item metadata for asset ${assetType} with id ${assetId} (${network}).`
+                `Failed to fetch item metadata for asset ${assetType} with id ${assetId} (${network}). Cause: ${JSON.stringify(error)}`
             );
         }
     }
 
     private deleteAssetData(asset: FileUpdateFlags) {
-        const {network, assetType, assetId } = asset;
+        const { network, assetType, assetId } = asset;
         logger.debug(`Deleting cache entry for ${network}/${assetType} asset id: ${assetId}`);
 
         const itemToChecksum = this.assetToItemChecksumMap.get(`${network}/${assetType}`);

--- a/src/services/tokenRegistryService.ts
+++ b/src/services/tokenRegistryService.ts
@@ -9,17 +9,23 @@ import logger from "../config/logger";
 const FILE_NAME_REGEXP = new RegExp(/(?<project>\S+)-(?<id>\w+).json/);
 
 /**
- * The key is a composite key of `${network}/${asset}`.
- * The value indicates if the specific asset folder has updated on github and should be re-fetched.
+ * The flag indicates if the specific file has updated(added, modified or deleted) on github and should be re-fetched.
  */
-interface AssetUpdateFlags {
-    [key: string]: boolean
+interface FileUpdateFlags {
+    network: string;
+    assetType: string;
+    projectName: string;
+    assetId: string;
+    sha: string;
+    shouldDelete?: boolean;
 }
 
 class TokenRegistryService {
     private readonly config: CONFIG;
 
     private assetToChecksum: Map<string, string> = new Map();
+
+    private assetToItemChecksumMap: Map<string, Map<string, string>> = new Map();
 
     private cache: Cache = {};
 
@@ -40,6 +46,7 @@ class TokenRegistryService {
             this.cache[network] = {};
             for (const asset of this.config.assets) {
                 this.cache[network][asset] = new Map<string, CacheEntry>()
+                this.assetToItemChecksumMap.set(`${network}/${asset}`, new Map<string, string>());
             }
         }
 
@@ -47,18 +54,13 @@ class TokenRegistryService {
     }
 
     private populateCache() {
-        void this.refreshFolderHashes().then((assetUpdateFlags: AssetUpdateFlags | undefined) => {
+        void this.refreshFolderHashes().then((fileUpdateFlags: FileUpdateFlags[]) => {
             logger.debug("Populating cache...");
-            for (const network of this.config.networks) {
-                for (const asset of this.config.assets) {
-                    const networkAssetKey = `${network}/${asset}`;
-                    const shouldRefreshData = assetUpdateFlags && assetUpdateFlags[networkAssetKey];
-
-                    if (shouldRefreshData) {
-                        void this.fetchAssetData(network, asset);
-                    } else {
-                        logger.debug(`Skipping fetch for asset data ${network}/${asset}. Nothing changed.`)
-                    }
+            for (const asset of fileUpdateFlags) {
+                if (asset.shouldDelete) {
+                    this.deleteAssetData(asset);
+                } else {
+                    void this.fetchAssetData(asset);
                 }
             }
         });
@@ -72,14 +74,15 @@ class TokenRegistryService {
         }).start();
     }
 
-    private async refreshFolderHashes(): Promise<AssetUpdateFlags | undefined> {
+    private async refreshFolderHashes(): Promise<FileUpdateFlags[]> {
         let response: AxiosResponse | undefined;
-        const result: AssetUpdateFlags = {};
+        const assetsToUpdate: string[] = [];
+        let itemsToUpdate: FileUpdateFlags[] = [];
 
         for (const network of this.config.networks) {
             try {
                 logger.debug("Refreshing network folder hashes");
-                response = await contentClient.get(`/${network}/`);
+                response = await contentClient.get(`/${network}`);
 
                 if (response?.status === 200) {
                     const networkAssets = response.data as GithubItem[];
@@ -93,13 +96,13 @@ class TokenRegistryService {
 
                             if (!existingSha) {
                                 this.assetToChecksum.set(mapKey, assetItem.sha);
-                                result[mapKey] = true;
+                                assetsToUpdate.push(mapKey);
                             } else {
                                 const shouldUpdate = existingSha !== assetItem.sha;
 
                                 if (shouldUpdate) {
                                     this.assetToChecksum.set(mapKey, assetItem.sha);
-                                    result[mapKey] = true;
+                                    assetsToUpdate.push(mapKey);
                                 }
                             }
                         } else {
@@ -109,88 +112,149 @@ class TokenRegistryService {
                 }
             } catch (error) {
                 logger.error(`Refreshing network folder hashes failed! ${JSON.stringify(error)}`);
-                return undefined;
+                return itemsToUpdate;
             }
         }
 
-        return result;
+        for (const asset of assetsToUpdate) {
+            const [network, assetType] = asset.split("/");
+            const fileUpdateFlags = await this.refreshItemHashes(network, assetType);
+            itemsToUpdate = [...itemsToUpdate, ...fileUpdateFlags];
+        }
+
+        return itemsToUpdate;
     }
 
-    private async fetchAssetData(network: string, assetType: string) {
+    private async refreshItemHashes(network: string, assetType: string): Promise<FileUpdateFlags[]> {
+        const mapKey = `${network}/${assetType}`;
         let response: AxiosResponse | undefined;
-        logger.info(`Fetching fresh asset ${assetType} for network ${network}`);
+        const itemsToUpdate: FileUpdateFlags[] = [];
 
-        const assetSha = this.assetToChecksum.get(`${network}/${assetType}`);
+        logger.info(`Refreshing file hashes for ${mapKey}`);
+        const assetSha = this.assetToChecksum.get(mapKey);
+        const itemToChecksum = this.assetToItemChecksumMap.get(mapKey);
 
-        if (!assetSha) {
-            logger.error(`Data fetch failed for '${network}/${assetType}'. Folder sha not found in map!`);
-            return;
+        if (!assetSha || !itemToChecksum) {
+            logger.error(`Data fetch failed for '${mapKey}'. Folder sha not found in map!`);
+            return itemsToUpdate;
         }
 
         try {
             response = await treeClient.get(`/${assetSha}`);
         } catch (error) {
-            logger.error(`Data fetch failed for '${network}/${assetType}'. ${JSON.stringify(error)}`);
-            return;
+            logger.error(`Data fetch failed for '${mapKey}'. ${JSON.stringify(error)}`);
+            return itemsToUpdate;
         }
 
         if (!response || response.status !== 200) {
             logger.error(
-                `Data fetch failed for '${network}/${assetType}'. Got response ${response?.status ?? "undefined"}`
+                `Data fetch failed for '${mapKey}'. Got response ${response?.status ?? "undefined"}`
             );
-            return;
+            return itemsToUpdate;
         }
 
         const githubTreeResponse = response.data as GithubTreeResponse;
         const githubTree = githubTreeResponse.tree;
-
-        logger.debug(`Fetched ${githubTree.length} ${assetType} for network ${network}`);
-
-        const assetCacheEntryUpdate = new Map<string, CacheEntry>();
+        let gitItemsCount = 0;
 
         for (const item of githubTree) {
-            if (item.type !== "blob" || item.path === ".gitkeep") {
-                continue;
-            }
-
             const fileName = item.path;
             const match = fileName.match(FILE_NAME_REGEXP);
 
-            if (match?.groups) {
+            if (match?.groups && itemToChecksum) {
                 const projectName = match.groups.project;
                 const assetId = match.groups.id;
 
-                try {
-                    const response = await blobsClient.get(`/${item.sha}`);
-                    if (!response || response.status !== 200) {
-                        throw new Error("Fetching metadata");
+                if (item.type !== "blob" || item.path === ".gitkeep") {
+                    continue;
+                }
+                gitItemsCount++;
+                const existingSha = itemToChecksum.get(assetId);
+
+                if (!existingSha) {
+                    itemToChecksum.set(assetId, item.sha);
+                    itemsToUpdate.push({
+                        network,
+                        assetType,
+                        projectName,
+                        assetId,
+                        sha: item.sha
+                    });
+                } else {
+                    const shouldUpdate = existingSha !== item.sha;
+
+                    if (shouldUpdate) {
+                        itemToChecksum.set(assetId, item.sha);
+                        itemsToUpdate.push({
+                            network,
+                            assetType,
+                            projectName,
+                            assetId,
+                            sha: item.sha
+                        });
                     }
-
-                    const githubBlob = response.data as GithubBlobItem;
-                    const metadata: object = JSON.parse(
-                        Buffer.from(
-                            githubBlob.content,
-                            "base64"
-                        ).toString("utf8")
-                    ) as object;
-
-
-                    if (metadata) {
-                        logger.debug(`Adding cache entry for ${network}/${assetType} asset id: ${assetId}`);
-                        assetCacheEntryUpdate.set(assetId, { projectName, metadata });
-                    } else {
-                        logger.warn(`Bad metadata content for ${assetType} with id ${assetId} (${network}). Skipping updating cache for this item.`);
-                    }
-                } catch {
-                    logger.error(
-                        `Failed to fetch item metadata for asset ${assetType} with id ${assetId} (${network}).`
-                    );
                 }
             }
         }
 
-        logger.info(`Refreshing asset data for ${network}/${assetType} finished! Replacing cache entry.`)
-        this.cache[network][assetType] = assetCacheEntryUpdate;
+        //find files that were deleted from github
+        if(itemToChecksum && gitItemsCount !== itemToChecksum.size) {
+            for (const [key, value] of itemToChecksum) {
+                const foundItem = githubTree.find(gitItem => value === gitItem.sha)
+                if (!foundItem) {
+                    itemsToUpdate.push({
+                        network,
+                        assetType,
+                        projectName: "",
+                        assetId: key,
+                        sha: value,
+                        shouldDelete: true
+                    });
+                }
+            }
+        }
+
+        return itemsToUpdate;
+    }
+
+    private async fetchAssetData(asset: FileUpdateFlags) {
+        const {network, assetType, projectName, assetId, sha} = asset;
+
+        try {
+            const response = await blobsClient.get(`/${sha}`);
+            if (!response || response.status !== 200) {
+                throw new Error("Fetching metadata");
+            }
+
+            const githubBlob = response.data as GithubBlobItem;
+            const metadata: object = JSON.parse(
+                Buffer.from(
+                    githubBlob.content,
+                    "base64"
+                ).toString("utf8")
+            ) as object;
+
+            if (metadata) {
+                logger.debug(`Adding cache entry for ${network}/${assetType} asset id: ${assetId}`);
+                this.cache[network][assetType].set(assetId, { projectName, metadata });
+            } else {
+                logger.warn(`Bad metadata content for ${assetType} with id ${assetId} (${network}). Skipping updating cache for this item.`);
+            }
+        } catch {
+            logger.error(
+                `Failed to fetch item metadata for asset ${assetType} with id ${assetId} (${network}).`
+            );
+        }
+    }
+
+    private deleteAssetData(asset: FileUpdateFlags) {
+        const {network, assetType, assetId } = asset;
+        logger.debug(`Deleting cache entry for ${network}/${assetType} asset id: ${assetId}`);
+
+        const itemToChecksum = this.assetToItemChecksumMap.get(`${network}/${assetType}`);
+        itemToChecksum?.delete(assetId);
+
+        this.cache[network][assetType].delete(assetId);
     }
 }
 

--- a/src/services/tokenRegistryService.ts
+++ b/src/services/tokenRegistryService.ts
@@ -23,10 +23,19 @@ interface FileUpdateFlags {
 class TokenRegistryService {
     private readonly config: CONFIG;
 
+    /**
+     * A map of assets (folders in github repo) to the corresponding folder checksum hash.
+    */
     private assetToChecksum: Map<string, string> = new Map();
 
+    /**
+     * A map of assets (folders in github repo) to a sub Map of contained files to file checksum hash.
+    */
     private assetToItemChecksumMap: Map<string, Map<string, string>> = new Map();
 
+    /**
+     * The cache object.
+    */
     private cache: Cache = {};
 
     constructor(config: CONFIG) {
@@ -93,12 +102,14 @@ class TokenRegistryService {
 
                     for (const asset of this.config.assets) {
                         const assetItem = networkAssets.find(na => na.name === asset);
+
                         if (assetItem) {
                             const mapKey = `${network}/${asset}`;
-                            logger.debug(`Adding to network/asset sha ${assetItem.sha} for ${network}/${asset}`);
+                            logger.debug(`Checking ${network}/${asset} folder sha...`);
                             const existingSha = this.assetToChecksum.get(mapKey);
 
                             if (!existingSha) {
+                                logger.debug(`Adding sha ${assetItem.sha} for ${network}/${asset}`);
                                 this.assetToChecksum.set(mapKey, assetItem.sha);
                                 assetsToUpdate.push(mapKey);
                             } else {
@@ -134,7 +145,7 @@ class TokenRegistryService {
         let response: AxiosResponse | undefined;
         const itemsToUpdate: FileUpdateFlags[] = [];
 
-        logger.info(`Refreshing file hashes for ${mapKey}`);
+        logger.info(`Refreshing file hashes for ${mapKey}...`);
         const assetSha = this.assetToChecksum.get(mapKey);
         const itemToChecksum = this.assetToItemChecksumMap.get(mapKey);
 


### PR DESCRIPTION
Improve cache refreshing to only update cached data for files that have been modified (added, updated or deleted).
resolves #6 